### PR TITLE
Refactor import statements and clean up minor code formatting

### DIFF
--- a/hpt-core/src/lib.rs
+++ b/hpt-core/src/lib.rs
@@ -279,13 +279,13 @@ pub use hpt_dataloader::{
 pub use hpt_macros::match_selection;
 pub use hpt_traits::*;
 pub use hpt_types::dtype::TypeCommon;
+pub use hpt_types::into_scalar::Cast;
+pub use hpt_types::into_vec::IntoVec;
 pub use hpt_types::traits::VecTrait;
 pub use hpt_types::type_promote::{
     BitWiseOut, Eval, FloatOutBinary, FloatOutBinaryPromote, FloatOutUnary, FloatOutUnaryPromote,
     NormalOut, NormalOutPromote, NormalOutUnary,
 };
-pub use hpt_types::into_scalar::Cast;
-pub use hpt_types::into_vec::IntoVec;
 pub use hpt_types::vectors::*;
 pub use serde;
 pub use tensor::Tensor;

--- a/hpt-dataloader/src/struct_save/save.rs
+++ b/hpt-dataloader/src/struct_save/save.rs
@@ -52,7 +52,6 @@ fn generate_header_compressed(
         CompressionAlgo,                   /* compression_algo */
         Endian,                            /* endian */
         Vec<(usize, usize, usize, usize)>, /* indices */
-
     ),
     (String, usize, usize, usize, usize),
 ) {

--- a/hpt-examples/examples/custom_type/main.rs
+++ b/hpt-examples/examples/custom_type/main.rs
@@ -579,10 +579,8 @@ impl Cast<f64> for CustomType {
     }
 }
 
-
 fn main() -> anyhow::Result<()> {
     let a = Tensor::<CustomType>::arange(0, 16)?.reshape(&[4, 4])?;
     println!("{}", a);
     Ok(())
 }
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,14 +4,14 @@ fn main() -> Result<(), TensorError> {
     // Matrix multiplication (2D tensordot)
     let a = Tensor::new(&[[1., 2.], [3., 4.]]);
     let b = Tensor::new(&[[5., 6.], [7., 8.]]);
-    let c = a.tensordot(&b, ([1], [0]))?;  // Contract last axis of a with first axis of b
+    let c = a.tensordot(&b, ([1], [0]))?; // Contract last axis of a with first axis of b
     println!("Matrix multiplication:\n{}", c);
 
     // Higher dimensional example
     let d = Tensor::<f32>::ones(&[2, 3, 4])?;
     let e = Tensor::<f32>::ones(&[4, 3, 2])?;
-    let f = d.tensordot(&e, ([1, 2], [1, 0]))?;  // Contract axes 1,2 of d with axes 1,0 of e
+    let f = d.tensordot(&e, ([1, 2], [1, 0]))?; // Contract axes 1,2 of d with axes 1,0 of e
     println!("Higher dimensional result:\n{}", f);
-    
+
     Ok(())
 }


### PR DESCRIPTION
- Reorder and organize import statements in hpt-core/lib.rs
- Remove extra newline in custom_type example
- Minor whitespace and formatting adjustments in main.rs