### PR TITLE
Refactor and clean up code formatting across multiple modules

### DIFF
--- a/hpt-dataloader/src/lib.rs
+++ b/hpt-dataloader/src/lib.rs
@@ -1,11 +1,11 @@
 mod compression_trait;
 pub mod data_loader;
-pub use compression_trait::{DataLoader, TensorLoader, TensorSaver};
-pub use flate2::write::{DeflateEncoder, GzEncoder, ZlibEncoder};
 pub use compression_trait::CompressionAlgo;
 pub use compression_trait::DataLoaderTrait;
 pub use compression_trait::Meta;
+pub use compression_trait::{DataLoader, TensorLoader, TensorSaver};
 pub use data_loader::Endian;
+pub use flate2::write::{DeflateEncoder, GzEncoder, ZlibEncoder};
 pub use from_safetensors::from_safetensors::FromSafeTensors;
 pub use struct_save::gen_header;
 pub use struct_save::load::{Load, MetaLoad};

--- a/hpt-examples/examples/resnet/main.rs
+++ b/hpt-examples/examples/resnet/main.rs
@@ -1,4 +1,3 @@
-
 use hpt::*;
 use safetensors::SafeTensors;
 
@@ -741,7 +740,11 @@ fn main() -> anyhow::Result<()> {
         }
         size.push(64 + 32 * i);
         time.push((now.elapsed() / 10).as_secs_f32() * 1000.0);
-        println!("size: {:?}, time: {:?}", size.last().unwrap(), time.last().unwrap());
+        println!(
+            "size: {:?}, time: {:?}",
+            size.last().unwrap(),
+            time.last().unwrap()
+        );
     }
     println!("size: {:?}", size);
     println!("time: {:?}", time);

--- a/hpt-tests/src/hpt/cpu/cumulate.rs
+++ b/hpt-tests/src/hpt/cpu/cumulate.rs
@@ -6,7 +6,7 @@ use duplicate::duplicate_item;
 use hpt::ShapeManipulate;
 use hpt::TensorInfo;
 use hpt::TensorLike;
-use hpt::{RandomInt, Tensor, TensorCreator, CumulativeOps};
+use hpt::{CumulativeOps, RandomInt, Tensor, TensorCreator};
 use hpt_common::slice;
 use hpt_common::slice::Slice;
 use hpt_macros::match_selection;

--- a/hpt-tests/src/hpt/cuda/binary.rs
+++ b/hpt-tests/src/hpt/cuda/binary.rs
@@ -69,7 +69,10 @@ fn no_assert_i64(b: &Tensor<i64, Cuda>, a: &TchTensor) {}
 fn common_input(
     lhs_shape: &[i64],
     rhs_shape: &[i64],
-) -> anyhow::Result<((TchTensor, TchTensor), (Tensor<f64, Cuda>, Tensor<f64, Cuda>))> {
+) -> anyhow::Result<(
+    (TchTensor, TchTensor),
+    (Tensor<f64, Cuda>, Tensor<f64, Cuda>),
+)> {
     let tch_a = TchTensor::randn(lhs_shape, (tch::Kind::Double, tch::Device::Cpu));
     let mut a = Tensor::<f64>::empty(lhs_shape)?;
     let a_size = a.size();
@@ -91,7 +94,10 @@ fn common_input(
 fn common_input_i64(
     lhs_shape: &[i64],
     rhs_shape: &[i64],
-) -> anyhow::Result<((TchTensor, TchTensor), (Tensor<i64, Cuda>, Tensor<i64, Cuda>))> {
+) -> anyhow::Result<(
+    (TchTensor, TchTensor),
+    (Tensor<i64, Cuda>, Tensor<i64, Cuda>),
+)> {
     let tch_a = TchTensor::arange(
         lhs_shape.iter().product::<i64>(),
         (tch::Kind::Int64, tch::Device::Cpu),

--- a/hpt-tests/src/lib.rs
+++ b/hpt-tests/src/lib.rs
@@ -2,6 +2,7 @@ pub mod hpt {
     pub mod cpu {
         pub mod adaptive_avg_pool;
         pub mod adaptive_max_pool;
+        pub mod assert_utils;
         pub mod avg_pool;
         pub mod binary;
         pub mod binary_out;
@@ -24,16 +25,14 @@ pub mod hpt {
         pub mod test_lib;
         pub mod topk;
         pub mod unary;
-        pub mod assert_utils;
     }
     #[cfg(feature = "cuda")]
     pub mod cuda {
-        pub mod creation;
-        pub mod binary;
-        pub mod unary;
-        pub mod reduce;
         pub mod assert_utils;
-
+        pub mod binary;
+        pub mod creation;
+        pub mod reduce;
+        pub mod unary;
     }
 }
 

--- a/hpt-traits/src/lib.rs
+++ b/hpt-traits/src/lib.rs
@@ -14,6 +14,8 @@ pub mod ops {
     pub mod cmp;
     /// A module contains conv operations
     pub mod conv;
+    /// A module contains cumulative operations
+    pub mod cumulative;
     /// A module contains fft operations
     pub mod fft;
     /// A module contains pooling operations
@@ -22,8 +24,6 @@ pub mod ops {
     pub mod uary;
     /// A module contains window operations
     pub mod windows;
-    /// A module contains cumulative operations
-    pub mod cumulative;
 }
 /// A module contains random number generation operations
 pub mod random;
@@ -34,11 +34,11 @@ pub use ops::advance::*;
 pub use ops::binary::*;
 pub use ops::cmp::*;
 pub use ops::conv::*;
+pub use ops::cumulative::*;
 pub use ops::fft::*;
 pub use ops::pooling::*;
 pub use ops::uary::*;
 pub use ops::windows::*;
 pub use random::*;
 pub use shape_manipulate::*;
-pub use ops::cumulative::*;
 pub use tensor::*;

--- a/hpt-types/src/cuda_types/_bf16.rs
+++ b/hpt-types/src/cuda_types/_bf16.rs
@@ -325,7 +325,9 @@ impl FloatOutUnary2 for Scalar<bf16> {
     }
 
     fn __selu(self, alpha: Self, scale: Self) -> Self {
-        self.to_f32().__selu(alpha.to_f32(), scale.to_f32()).to_bf16()
+        self.to_f32()
+            .__selu(alpha.to_f32(), scale.to_f32())
+            .to_bf16()
     }
 
     fn __hard_sigmoid(self) -> Self {

--- a/hpt-types/src/cuda_types/_f16.rs
+++ b/hpt-types/src/cuda_types/_f16.rs
@@ -312,7 +312,9 @@ impl FloatOutUnary2 for Scalar<f16> {
     }
 
     fn __selu(self, alpha: Self, scale: Self) -> Self {
-        self.to_f32().__selu(alpha.to_f32(), scale.to_f32()).to_f16()
+        self.to_f32()
+            .__selu(alpha.to_f32(), scale.to_f32())
+            .to_f16()
     }
 
     fn __hard_sigmoid(self) -> Self {

--- a/hpt/src/lib.rs
+++ b/hpt/src/lib.rs
@@ -180,6 +180,8 @@ pub mod ops {
             pub(crate) mod arg_reduce;
             /// a module contains cuda tensor common reduce impls
             pub(crate) mod common_reduce;
+            /// a module contains cuda tensor float out binary impls
+            pub(crate) mod float_out_binary;
             /// a module contains cuda tensor float out unary impls
             pub(crate) mod float_out_unary;
             /// a module contains cuda matmul impls
@@ -194,8 +196,6 @@ pub mod ops {
             pub(crate) mod shape_manipulate;
             /// a module contains cuda tensor windows impls
             pub(crate) mod windows;
-            /// a module contains cuda tensor float out binary impls
-            pub(crate) mod float_out_binary;
         }
         pub mod tensor_external {
             /// a module contains cuda tensor arg reduce impls
@@ -204,6 +204,8 @@ pub mod ops {
             pub(crate) mod cmp;
             /// a module contains cuda tensor common reduce impls
             pub(crate) mod common_reduce;
+            /// a module contains cuda tensor float out binary impls
+            pub(crate) mod float_out_binary;
             /// a module contains cuda tensor float out unary impls
             pub(crate) mod float_out_unary;
             /// a module contains cuda tensor matmul impls
@@ -220,8 +222,6 @@ pub mod ops {
             pub(crate) mod slice;
             /// a module contains cuda tensor windows impls
             pub(crate) mod windows;
-            /// a module contains cuda tensor float out binary impls
-            pub(crate) mod float_out_binary;
         }
         pub(crate) mod utils {
             pub(crate) mod reduce {
@@ -285,7 +285,7 @@ pub use hpt_dataloader::{
     CompressionAlgo, DataLoader, Endian, FromSafeTensors, Load, MetaLoad, Save, TensorLoader,
     TensorSaver,
 };
-pub use hpt_macros::{match_selection, Save, Load};
+pub use hpt_macros::{match_selection, Load, Save};
 pub use hpt_traits::*;
 pub use hpt_types::dtype::TypeCommon;
 pub use hpt_types::into_scalar::Cast;

--- a/hpt/src/ops/cpu/tensor_external/float_out_binary.rs
+++ b/hpt/src/ops/cpu/tensor_external/float_out_binary.rs
@@ -1,9 +1,7 @@
 use hpt_traits::{CommonBounds, FloatBinOps};
 use hpt_types::{dtype::TypeCommon, type_promote::FloatOutBinary};
 
-use crate::{
-    ops::cpu::tensor_internal::float_out_unary::FloatBinaryType, Cpu, Tensor,
-};
+use crate::{ops::cpu::tensor_internal::float_out_unary::FloatBinaryType, Cpu, Tensor};
 
 impl<T, const DEVICE: usize> FloatBinOps for Tensor<T, Cpu, DEVICE>
 where

--- a/hpt/src/ops/cpu/tensor_internal/common_reduce.rs
+++ b/hpt/src/ops/cpu/tensor_internal/common_reduce.rs
@@ -479,8 +479,7 @@ where
 impl<T, const DEVICE: usize> FloatReduce<T> for _Tensor<T, Cpu, DEVICE>
 where
     T: FloatOutBinary + CommonBounds + Cast<FloatBinaryType<T>>,
-    FloatBinaryType<T>:
-        CommonBounds + FloatOutUnary<Output = FloatBinaryType<T>>,
+    FloatBinaryType<T>: CommonBounds + FloatOutUnary<Output = FloatBinaryType<T>>,
     <FloatBinaryType<T> as TypeCommon>::Vec: NormalOut<T::Vec, Output = <FloatBinaryType<T> as TypeCommon>::Vec>
         + FloatOutUnary<Output = <FloatBinaryType<T> as TypeCommon>::Vec>
         + NormalOut<
@@ -500,7 +499,7 @@ where
     >,
 {
     type Output = _Tensor<FloatBinaryType<T>, Cpu, DEVICE>;
-    
+
     #[track_caller]
     fn mean<S: Into<Axis>>(
         &self,
@@ -530,7 +529,7 @@ where
             None,
         )
     }
-    
+
     #[allow(unused)]
     #[track_caller]
     fn reducel2<S: Into<Axis>>(

--- a/hpt/src/ops/cpu/tensor_internal/float_out_binary.rs
+++ b/hpt/src/ops/cpu/tensor_internal/float_out_binary.rs
@@ -40,13 +40,7 @@ where
     where
         U: std::borrow::BorrowMut<Self::InplaceOutput>,
     {
-        binary_fn_with_out_simd(
-            self,
-            rhs,
-            |a, b| a._hypot(b),
-            |a, b| a._hypot(b),
-            Some(out),
-        )
+        binary_fn_with_out_simd(self, rhs, |a, b| a._hypot(b), |a, b| a._hypot(b), Some(out))
     }
 
     fn div_<U>(
@@ -57,12 +51,6 @@ where
     where
         U: std::borrow::BorrowMut<Self::InplaceOutput>,
     {
-        binary_fn_with_out_simd(
-            self,
-            rhs,
-            |a, b| a._div(b),
-            |a, b| a._div(b),
-            Some(out),
-        )
+        binary_fn_with_out_simd(self, rhs, |a, b| a._div(b), |a, b| a._div(b), Some(out))
     }
 }

--- a/hpt/src/ops/cpu/tensor_internal/float_out_unary.rs
+++ b/hpt/src/ops/cpu/tensor_internal/float_out_unary.rs
@@ -618,7 +618,7 @@ where
             );
         Ok((res1.clone(), res2.clone()))
     }
-    
+
     fn erf_<U>(&self, out: U) -> std::result::Result<Self::InplaceOutput, TensorError>
     where
         U: BorrowMut<Self::InplaceOutput>,

--- a/hpt/src/ops/cpu/utils/reduce/reduce.rs
+++ b/hpt/src/ops/cpu/utils/reduce/reduce.rs
@@ -1,7 +1,7 @@
 use crate::backend::Cpu;
+use crate::ops::cpu::kernels::argreduce_kernels::{argmax_kernel, argmin_kernel};
 use crate::ops::cpu::utils::reduce::reduce_template::contiguous_reduce_template;
 use crate::tensor_base::_Tensor;
-use crate::ops::cpu::kernels::argreduce_kernels::{argmax_kernel, argmin_kernel};
 
 use crate::ops::cpu::utils::reduce::reduce_utils::{
     ReductionPreprocessor, UCReductionPreprocessor,

--- a/hpt/src/ops/cuda/std_ops.rs
+++ b/hpt/src/ops/cuda/std_ops.rs
@@ -1500,9 +1500,8 @@ where
     #[track_caller]
     fn shl(self, rhs: rhs_type<T, Cuda, DEVICE>) -> Self::Output {
         let lhs: Tensor<lhs_type> = self.into();
-        let lhs: Tensor<lhs_type, Cuda, DEVICE> = lhs
-            .to_cuda::<DEVICE>()
-            .expect("Failed to convert to cuda");
+        let lhs: Tensor<lhs_type, Cuda, DEVICE> =
+            lhs.to_cuda::<DEVICE>().expect("Failed to convert to cuda");
         lhs.inner.as_ref().shl(rhs.inner.as_ref()).into()
     }
 }
@@ -1688,9 +1687,8 @@ where
     #[track_caller]
     fn shr(self, rhs: rhs_type<T, Cuda, DEVICE>) -> Self::Output {
         let lhs: Tensor<lhs_type> = self.into();
-        let lhs: Tensor<lhs_type, Cuda, DEVICE> = lhs
-            .to_cuda::<DEVICE>()
-            .expect("Failed to convert to cuda");
+        let lhs: Tensor<lhs_type, Cuda, DEVICE> =
+            lhs.to_cuda::<DEVICE>().expect("Failed to convert to cuda");
         lhs.inner.as_ref().shr(rhs.inner.as_ref()).into()
     }
 }

--- a/hpt/src/ops/cuda/tensor_external/float_out_unary.rs
+++ b/hpt/src/ops/cuda/tensor_external/float_out_unary.rs
@@ -528,15 +528,11 @@ where
         )?
         .into())
     }
-    
+
     fn erf_<U>(&self, mut out: U) -> std::result::Result<Self::InplaceOutput, TensorError>
     where
         U: BorrowMut<Self::InplaceOutput>,
     {
-        Ok(_Tensor::erf_(
-            self.inner.as_ref(),
-            out.borrow_mut().inner.as_ref().clone(),
-        )?
-        .into())
+        Ok(_Tensor::erf_(self.inner.as_ref(), out.borrow_mut().inner.as_ref().clone())?.into())
     }
 }

--- a/hpt/src/ops/cuda/tensor_external/matmul.rs
+++ b/hpt/src/ops/cuda/tensor_external/matmul.rs
@@ -1,5 +1,6 @@
 use std::borrow::{Borrow, BorrowMut};
 
+use crate::{ops::cuda::tensor_internal::matmul::matmul_with_out, tensor::Tensor, Cuda};
 use cudarc::{
     cublas::{CudaBlas, Gemm},
     driver::DeviceRepr,
@@ -7,7 +8,6 @@ use cudarc::{
 use hpt_common::error::base::TensorError;
 use hpt_traits::{CommonBounds, Matmul};
 use hpt_types::dtype::CudaType;
-use crate::{ops::cuda::tensor_internal::matmul::matmul_with_out, tensor::Tensor, Cuda};
 impl<T, const CUDA_DEVICE: usize> Matmul<Tensor<T, Cuda, CUDA_DEVICE>>
     for Tensor<T, Cuda, CUDA_DEVICE>
 where

--- a/hpt/src/ops/cuda/tensor_internal/float_out_unary.rs
+++ b/hpt/src/ops/cuda/tensor_internal/float_out_unary.rs
@@ -757,7 +757,7 @@ where
             Some(out),
         )
     }
-    
+
     fn erf_<U>(&self, out: U) -> std::result::Result<Self::InplaceOutput, TensorError>
     where
         U: BorrowMut<Self::InplaceOutput>,

--- a/hpt/src/ops/cuda/utils/binary/binary_normal.rs
+++ b/hpt/src/ops/cuda/utils/binary/binary_normal.rs
@@ -367,7 +367,10 @@ where
                 res.device(),
                 &["binop"],
             )?;
-            let kernel = res.device().get_func(&module_name, "binop").expect("func_name not found");
+            let kernel = res
+                .device()
+                .get_func(&module_name, "binop")
+                .expect("func_name not found");
             let out_slice = res.cuda_slice();
             let rhs_slice = rhs.cuda_slice();
             let lhs_slice = lhs.cuda_slice();

--- a/hpt/src/ops/cuda/utils/unary/strided_copy.rs
+++ b/hpt/src/ops/cuda/utils/unary/strided_copy.rs
@@ -1,5 +1,5 @@
 use crate::ops::cuda::cuda_utils::{
-    compile_kernel, compute_kernel_launch_config, get_array_str, get_include_1, get_module_name_1
+    compile_kernel, compute_kernel_launch_config, get_array_str, get_include_1, get_module_name_1,
 };
 use crate::tensor_base::_Tensor;
 use crate::Cuda;

--- a/hpt/src/tensor.rs
+++ b/hpt/src/tensor.rs
@@ -206,7 +206,9 @@ impl<T, const DEVICE_ID: usize> From<Tensor<T, Cpu, DEVICE_ID>> for DataLoader<T
     }
 }
 
-impl<T: CommonBounds, B: BackendTy + Buffer, const DEVICE: usize> CPUTensorCreator<T> for Tensor<T, B, DEVICE> {
+impl<T: CommonBounds, B: BackendTy + Buffer, const DEVICE: usize> CPUTensorCreator<T>
+    for Tensor<T, B, DEVICE>
+{
     type Output = Tensor<T, Cpu, DEVICE>;
     fn empty<S: Into<Shape>>(shape: S) -> Result<Self::Output, TensorError> {
         <Tensor<T, Cpu, DEVICE> as TensorCreator<T>>::empty(shape)


### PR DESCRIPTION
- Reorganize module imports in various files
- Improve code formatting and remove unnecessary whitespace
- Standardize import order and remove redundant module declarations
- Minor adjustments to code structure in CUDA and CPU tensor operations