### PR TITLE
Add Linear struct with CUDA tensor initialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ exclude = [
 ]
 
 [dependencies]
-hpt = { path = "./hpt", features = ["track_caller", "cuda"], version = "0.0.15" }
+hpt = { path = "./hpt", features = ["track_caller"], version = "0.0.15" }
 # hpt = {version = "0.0.11", features = ["cuda"]}
 anyhow = "1.0.95"
 candle-core = { version = "0.8.2", features = ["mkl"] }

--- a/hpt/src/ops/cpu/tensor_impls.rs
+++ b/hpt/src/ops/cpu/tensor_impls.rs
@@ -391,6 +391,7 @@ impl<T: Clone, const DEVICE: usize> DiffTensor<T, Cpu, DEVICE> {
     }
 }
 
+#[cfg(feature = "cuda")]
 impl<T: CommonBounds, const CPU_DEVICE: usize, const CUDA_DEVICE: usize>
     Into<Tensor<T, Cuda, CUDA_DEVICE>> for Tensor<T, Cpu, CPU_DEVICE>
 where


### PR DESCRIPTION
- Implement Linear struct with weight and bias tensors
- Add new tensor creation methods using CUDA backend
- Remove CUDA feature from main project's hpt dependency
- Conditionally add CUDA conversion implementation in tensor_impls.rs