### PR TITLE
Update documentation for tensor operations with mutable output parameter

### DIFF
--- a/docs/user_guide/binary/add_.md
+++ b/docs/user_guide/binary/add_.md
@@ -3,7 +3,7 @@
 add_(
     x: &Tensor<A> | Tensor<A> | scalar, 
     y: &Tensor<B> | Tensor<B> | scalar,
-    out: &Tensor<C> | Tensor<C>
+    out: &mut Tensor<C> | Tensor<C>
 ) -> Result<Tensor<C>, TensorError>
 ```
 Compute $\large x + y$ for all elements with out
@@ -20,12 +20,12 @@ Tensor with type `C`
 
 ## Examples:
 ```rust
-use hpt::{FloatBinaryOps, Tensor, TensorError};
+use hpt::{NormalBinOps, Tensor, TensorError};
 
 fn main() -> Result<(), TensorError> {
     let a = Tensor::<f32>::new([2.0]);
     let b = Tensor::<f32>::new([3.0]);
-    let c = a.add_(&b, &a)?;
+    let c = a.add_(&b, &mut a.clone())?;
     println!("{}", c);
     Ok(())
 }

--- a/docs/user_guide/binary/div_.md
+++ b/docs/user_guide/binary/div_.md
@@ -3,7 +3,7 @@
 div_(
     x: &Tensor<A> | Tensor<A> | scalar, 
     y: &Tensor<B> | Tensor<B> | scalar,
-    out: &Tensor<C> | Tensor<C>
+    out: &mut Tensor<C> | Tensor<C>
 ) -> Result<Tensor<C>, TensorError>
 ```
 Compute $\large x / y$ for all elements with out
@@ -20,12 +20,12 @@ Tensor with type `C`
 
 ## Examples:
 ```rust
-use hpt::{FloatBinaryOps, Tensor, TensorError};
+use hpt::{FloatBinOps, Tensor, TensorError};
 
 fn main() -> Result<(), TensorError> {
     let a = Tensor::<f32>::new([2.0]);
     let b = Tensor::<f32>::new([3.0]);
-    let c = a.div_(&b, &a)?;
+    let c = a.div_(&b, &mut a.clone())?;
     println!("{}", c);
     Ok(())
 }

--- a/docs/user_guide/binary/mul_.md
+++ b/docs/user_guide/binary/mul_.md
@@ -3,7 +3,7 @@
 mul_(
     x: &Tensor<A> | Tensor<A> | scalar, 
     y: &Tensor<B> | Tensor<B> | scalar,
-    out: &Tensor<C> | Tensor<C>
+    out: &mut Tensor<C> | Tensor<C>
 ) -> Result<Tensor<C>, TensorError>
 ```
 Compute $\large x * y$ for all elements with out

--- a/docs/user_guide/binary/sub_.md
+++ b/docs/user_guide/binary/sub_.md
@@ -3,7 +3,7 @@
 sub_(
     x: &Tensor<A> | Tensor<A> | scalar, 
     y: &Tensor<B> | Tensor<B> | scalar,
-    out: &Tensor<C> | Tensor<C>
+    out: &mut Tensor<C> | Tensor<C>
 ) -> Result<Tensor<C>, TensorError>
 ```
 Compute $\large x - y$ for all elements with out
@@ -20,12 +20,12 @@ Tensor with type `C`
 
 ## Examples:
 ```rust
-use hpt::{FloatBinaryOps, Tensor, TensorError};
+use hpt::{NormalBinOps, Tensor, TensorError};
 
 fn main() -> Result<(), TensorError> {
     let a = Tensor::<f32>::new([2.0]);
     let b = Tensor::<f32>::new([3.0]);
-    let c = a.sub_(&b, &a)?;
+    let c = a.mul_(&b, &mut a.clone())?;
     println!("{}", c);
     Ok(())
 }

--- a/docs/user_guide/unary/abs_.md
+++ b/docs/user_guide/unary/abs_.md
@@ -2,7 +2,7 @@
 ```rust
 abs_(
     x: &Tensor<T>, 
-    out: &Tensor<T> | Tensor<T>
+    out: &mut Tensor<T> | Tensor<T>
 ) -> Result<Tensor<T>, TensorError>
 ```
 Calculate absolute of input with out

--- a/docs/user_guide/unary/acos_.md
+++ b/docs/user_guide/unary/acos_.md
@@ -2,7 +2,7 @@
 ```rust
 acos_(
     x: &Tensor<T>, 
-    out: &Tensor<C> | Tensor<C>
+    out: &mut Tensor<C> | Tensor<C>
 ) -> Result<Tensor<C>, TensorError>
 ```
 Inverse cosine with out

--- a/docs/user_guide/unary/acosh_.md
+++ b/docs/user_guide/unary/acosh_.md
@@ -2,7 +2,7 @@
 ```rust
 acosh_(
     x: &Tensor<T>, 
-    out: &Tensor<C> | Tensor<C>
+    out: &mut Tensor<C> | Tensor<C>
 ) -> Result<Tensor<C>, TensorError>
 ```
 Inverse hyperbolic cosine with out

--- a/docs/user_guide/unary/asin_.md
+++ b/docs/user_guide/unary/asin_.md
@@ -2,7 +2,7 @@
 ```rust
 asin_(
     x: &Tensor<T>, 
-    out: &Tensor<C> | Tensor<C>
+    out: &mut Tensor<C> | Tensor<C>
 ) -> Result<Tensor<C>, TensorError>
 ```
 Inverse sine with out

--- a/docs/user_guide/unary/asinh_.md
+++ b/docs/user_guide/unary/asinh_.md
@@ -2,7 +2,7 @@
 ```rust
 asinh_(
     x: &Tensor<T>, 
-    out: &Tensor<C> | Tensor<C>
+    out: &mut Tensor<C> | Tensor<C>
 ) -> Result<Tensor<C>, TensorError>
 ```
 Inverse hyperbolic sine with out

--- a/docs/user_guide/unary/atan_.md
+++ b/docs/user_guide/unary/atan_.md
@@ -2,7 +2,7 @@
 ```rust
 atan_(
     x: &Tensor<T>, 
-    out: &Tensor<C> | Tensor<C>
+    out: &mut Tensor<C> | Tensor<C>
 ) -> Result<Tensor<C>, TensorError>
 ```
 Inverse tangent with out

--- a/docs/user_guide/unary/atanh_.md
+++ b/docs/user_guide/unary/atanh_.md
@@ -2,7 +2,7 @@
 ```rust
 atanh_(
     x: &Tensor<T>, 
-    out: &Tensor<C> | Tensor<C>
+    out: &mut Tensor<C> | Tensor<C>
 ) -> Result<Tensor<C>, TensorError>
 ```
 Inverse hyperbolic tangent with out

--- a/docs/user_guide/unary/cbrt_.md
+++ b/docs/user_guide/unary/cbrt_.md
@@ -1,6 +1,6 @@
 # cbrt_
 ```rust
-cbrt_(x: &Tensor<T>, out: &Tensor<C>) -> Result<Tensor<C>, TensorError>
+cbrt_(x: &Tensor<T>, out: &mut Tensor<C> | Tensor<C>) -> Result<Tensor<C>, TensorError>
 ```
 Compute $\large \sqrt[3]{x}$ for all elements with out
 

--- a/docs/user_guide/unary/celu_.md
+++ b/docs/user_guide/unary/celu_.md
@@ -1,6 +1,6 @@
 # celu_
 ```rust
-celu_(x: &Tensor<T>, alpha: C, out: &Tensor<C>) -> Result<Tensor<C>, TensorError>
+celu_(x: &Tensor<T>, alpha: C, out: &mut Tensor<C> | Tensor<C>) -> Result<Tensor<C>, TensorError>
 ```
 Compute $\large \text{max}(0, x) + \text{min}(0, \alpha \cdot (e^{x/\alpha} - 1))$ for all elements with out
 

--- a/docs/user_guide/unary/cos_.md
+++ b/docs/user_guide/unary/cos_.md
@@ -2,7 +2,7 @@
 ```rust
 cos_(
     x: &Tensor<T>, 
-    out: &Tensor<C> | Tensor<C>
+    out: &mut Tensor<C> | Tensor<C>
 ) -> Result<Tensor<C>, TensorError>
 ```
 Trigonometric cosine with out

--- a/docs/user_guide/unary/cosh_.md
+++ b/docs/user_guide/unary/cosh_.md
@@ -2,7 +2,7 @@
 ```rust
 cosh_(
     x: &Tensor<T>, 
-    out: &Tensor<C> | Tensor<C>
+    out: &mut Tensor<C> | Tensor<C>
 ) -> Result<Tensor<C>, TensorError>
 ```
 Hyperbolic cosine with out

--- a/docs/user_guide/unary/elu_.md
+++ b/docs/user_guide/unary/elu_.md
@@ -1,6 +1,6 @@
 # elu_
 ```rust
-elu_(x: &Tensor<T>, alpha: C, out: &Tensor<C>) -> Result<Tensor<C>, TensorError>
+elu_(x: &Tensor<T>, alpha: C, out: &mut Tensor<C> | Tensor<C>) -> Result<Tensor<C>, TensorError>
 ```
 Compute $\large x$ for $x > 0$, $\large \alpha(e^x - 1)$ for $x \leq 0$ for all elements with out
 

--- a/docs/user_guide/unary/erf_.md
+++ b/docs/user_guide/unary/erf_.md
@@ -1,6 +1,6 @@
 # erf_
 ```rust
-erf_(x: &Tensor<T>, out: &Tensor<C>) -> Result<Tensor<C>, TensorError>
+erf_(x: &Tensor<T>, out: &mut Tensor<C> | Tensor<C>) -> Result<Tensor<C>, TensorError>
 ```
 Compute $\large \text{erf}(x) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$ for all elements with out
 

--- a/docs/user_guide/unary/exp2_.md
+++ b/docs/user_guide/unary/exp2_.md
@@ -2,7 +2,7 @@
 ```rust
 exp2_(
     x: &Tensor<T>, 
-    out: &Tensor<C> | Tensor<C>
+    out: &mut Tensor<C> | Tensor<C>
 ) -> Result<Tensor<C>, TensorError>
 ```
 Compute $\large 2^x$ for all elements with out

--- a/docs/user_guide/unary/exp_.md
+++ b/docs/user_guide/unary/exp_.md
@@ -2,7 +2,7 @@
 ```rust
 exp_(
     x: &Tensor<T>, 
-    out: &Tensor<C> | Tensor<C>
+    out: &mut Tensor<C> | Tensor<C>
 ) -> Result<Tensor<C>, TensorError>
 ```
 Compute exponential of `x` for all elements with out

--- a/docs/user_guide/unary/gelu_.md
+++ b/docs/user_guide/unary/gelu_.md
@@ -1,6 +1,6 @@
 # gelu_
 ```rust
-gelu_(x: &Tensor<T>, out: &Tensor<C>) -> Result<Tensor<C>, TensorError>
+gelu_(x: &Tensor<T>, out: &mut Tensor<C> | Tensor<C>) -> Result<Tensor<C>, TensorError>
 ```
 Compute $\large x \cdot \Phi(x)$ where $\Phi(x)$ is the cumulative distribution function of the standard normal distribution for all elements with out
 

--- a/docs/user_guide/unary/hard_sigmoid_.md
+++ b/docs/user_guide/unary/hard_sigmoid_.md
@@ -1,6 +1,6 @@
 # hard_sigmoid_
 ```rust
-hard_sigmoid_(x: &Tensor<T>, out: &Tensor<C>) -> Result<Tensor<C>, TensorError>
+hard_sigmoid_(x: &Tensor<T>, out: &mut Tensor<C> | Tensor<C>) -> Result<Tensor<C>, TensorError>
 ```
 Compute $\large \text{max}(0, \text{min}(1, \frac{x}{6} + 0.5))$ for all elements with out. A piece-wise linear approximation of the sigmoid function.
 

--- a/docs/user_guide/unary/hard_swish_.md
+++ b/docs/user_guide/unary/hard_swish_.md
@@ -1,6 +1,6 @@
 # hard_swish_
 ```rust
-hard_swish_(x: &Tensor<T>, out: &Tensor<C>) -> Result<Tensor<C>, TensorError>
+hard_swish_(x: &Tensor<T>, out: &mut Tensor<C> | Tensor<C>) -> Result<Tensor<C>, TensorError>
 ```
 Compute $\large x \cdot \text{min}(\text{max}(0, \frac{x}{6} + 0.5), 1)$ for all elements with out. A piece-wise linear approximation of the swish function.
 

--- a/docs/user_guide/unary/ln_.md
+++ b/docs/user_guide/unary/ln_.md
@@ -1,6 +1,6 @@
 # ln_
 ```rust
-ln_(x: &Tensor<T>, out: &Tensor<C>) -> Result<Tensor<C>, TensorError>
+ln_(x: &Tensor<T>, out: &mut Tensor<C> | Tensor<C>) -> Result<Tensor<C>, TensorError>
 ```
 Compute $\large \ln(x)$ for all elements with out
 

--- a/docs/user_guide/unary/log10_.md
+++ b/docs/user_guide/unary/log10_.md
@@ -1,6 +1,6 @@
 # log10_
 ```rust
-log10_(x: &Tensor<T>, out: &Tensor<C>) -> Result<Tensor<C>, TensorError>
+log10_(x: &Tensor<T>, out: &mut Tensor<C> | Tensor<C>) -> Result<Tensor<C>, TensorError>
 ```
 Compute $\large \log_{10}(x)$ for all elements with out
 

--- a/docs/user_guide/unary/log2_.md
+++ b/docs/user_guide/unary/log2_.md
@@ -1,6 +1,6 @@
 # log2_
 ```rust
-log2_(x: &Tensor<T>, out: &Tensor<C>) -> Result<Tensor<C>, TensorError>
+log2_(x: &Tensor<T>, out: &mut Tensor<C> | Tensor<C>) -> Result<Tensor<C>, TensorError>
 ```
 Compute $\large \log_{2}(x)$ for all elements with out
 

--- a/docs/user_guide/unary/mish_.md
+++ b/docs/user_guide/unary/mish_.md
@@ -1,6 +1,6 @@
 # mish_
 ```rust
-mish_(x: &Tensor<T>, out: &Tensor<C>) -> Result<Tensor<C>, TensorError>
+mish_(x: &Tensor<T>, out: &mut Tensor<C> | Tensor<C>) -> Result<Tensor<C>, TensorError>
 ```
 Compute $\large x * \tanh(\ln(1 + e^x))$ for all elements with out
 

--- a/docs/user_guide/unary/recip_.md
+++ b/docs/user_guide/unary/recip_.md
@@ -1,6 +1,6 @@
 # recip_
 ```rust
-recip_(x: &Tensor<T>, out: &Tensor<C>) -> Result<Tensor<C>, TensorError>
+recip_(x: &Tensor<T>, out: &mut Tensor<C> | Tensor<C>) -> Result<Tensor<C>, TensorError>
 ```
 Compute $\large \frac{1}{x}$ for all elements with out
 

--- a/docs/user_guide/unary/selu_.md
+++ b/docs/user_guide/unary/selu_.md
@@ -4,7 +4,7 @@ selu_(
     x: &Tensor<T>, 
     alpha: C | None, 
     gamma: C | None,
-    out: &Tensor<C> | Tensor<C>
+    out: &mut Tensor<C> | Tensor<C>
 ) -> Result<Tensor<C>, TensorError>
 ```
 Compute $\large \lambda * (\alpha * (e^x - 1))$ for $x < 0$, $\large \lambda * x$ for $x \geq 0$ for all elements

--- a/docs/user_guide/unary/sigmoid_.md
+++ b/docs/user_guide/unary/sigmoid_.md
@@ -1,6 +1,6 @@
 # sigmoid_
 ```rust
-sigmoid_(x: &Tensor<T>, out: &Tensor<C>) -> Result<Tensor<C>, TensorError>
+sigmoid_(x: &Tensor<T>, out: &mut Tensor<C> | Tensor<C>) -> Result<Tensor<C>, TensorError>
 ```
 Compute $\large \frac{1}{1 + e^{-x}}$ for all elements with out
 

--- a/docs/user_guide/unary/sin_.md
+++ b/docs/user_guide/unary/sin_.md
@@ -2,7 +2,7 @@
 ```rust
 sin_(
     x: &Tensor<T>, 
-    out: &Tensor<C> | Tensor<C>
+    out: &mut Tensor<C> | Tensor<C>
 ) -> Result<Tensor<C>, TensorError>
 ```
 Trigonometric sine with out

--- a/docs/user_guide/unary/sinh_.md
+++ b/docs/user_guide/unary/sinh_.md
@@ -2,7 +2,7 @@
 ```rust
 sinh_(
     x: &Tensor<T>, 
-    out: &Tensor<C> | Tensor<C>
+    out: &mut Tensor<C> | Tensor<C>
 ) -> Result<Tensor<C>, TensorError>
 ```
 Hyperbolic sine with out

--- a/docs/user_guide/unary/softplus_.md
+++ b/docs/user_guide/unary/softplus_.md
@@ -1,6 +1,6 @@
 # softplus_
 ```rust
-softplus_(x: &Tensor<T>, out: &Tensor<C>) -> Result<Tensor<C>, TensorError>
+softplus_(x: &Tensor<T>, out: &mut Tensor<C> | Tensor<C>) -> Result<Tensor<C>, TensorError>
 ```
 Compute $\ln(1 + e^x)$ for all elements with out
 

--- a/docs/user_guide/unary/softsign_.md
+++ b/docs/user_guide/unary/softsign_.md
@@ -1,6 +1,6 @@
 # softsign_
 ```rust
-softsign_(x: &Tensor<T>, out: &Tensor<C>) -> Result<Tensor<C>, TensorError>
+softsign_(x: &Tensor<T>, out: &mut Tensor<C> | Tensor<C>) -> Result<Tensor<C>, TensorError>
 ```
 Compute $\large \frac{x}{1 + |x|}$ for all elements with out
 

--- a/docs/user_guide/unary/sqrt_.md
+++ b/docs/user_guide/unary/sqrt_.md
@@ -1,6 +1,6 @@
 # sqrt_
 ```rust
-sqrt_(x: &Tensor<T>, out: &Tensor<C>) -> Result<Tensor<C>, TensorError>
+sqrt_(x: &Tensor<T>, out: &mut Tensor<C> | Tensor<C>) -> Result<Tensor<C>, TensorError>
 ```
 Compute $\large \sqrt{x}$ for all elements with out
 

--- a/docs/user_guide/unary/tan_.md
+++ b/docs/user_guide/unary/tan_.md
@@ -2,7 +2,7 @@
 ```rust
 tan_(
     x: &Tensor<T>, 
-    out: &Tensor<C> | Tensor<C>
+    out: &mut Tensor<C> | Tensor<C>
 ) -> Result<Tensor<C>, TensorError>
 ```
 Trigonometric tangent with out

--- a/docs/user_guide/unary/tanh_.md
+++ b/docs/user_guide/unary/tanh_.md
@@ -2,7 +2,7 @@
 ```rust
 tanh_(
     x: &Tensor<T>, 
-    out: &Tensor<C> | Tensor<C>
+    out: &mut Tensor<C> | Tensor<C>
 ) -> Result<Tensor<C>, TensorError>
 ```
 Hyperbolic tangent with out

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,8 @@
-fn main() -> anyhow::Result<()> {
+use hpt::{TensorCmp, Tensor, TensorError};
+
+fn main() -> Result<(), TensorError> {
+    let a = Tensor::<f32>::new([2.0, 2.0, 2.0]);
+    let b = a.tensor_eq(&a)?;
+    println!("{}", b); // [true true true]
     Ok(())
 }


### PR DESCRIPTION
- Modify function signatures in binary and unary operation documentation
- Change output parameter from immutable reference to mutable reference
- Update example code to reflect new function signatures
- Adjust import statements in documentation examples
- Standardize documentation across tensor operation files