### PR TITLE
Conditionally import DeviceRepr for CUDA feature

### DIFF
--- a/hpt/src/ops/common/divmod.rs
+++ b/hpt/src/ops/common/divmod.rs
@@ -1,5 +1,3 @@
-use cudarc::driver::DeviceRepr;
-
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 pub(crate) struct FastDivmod {
@@ -64,4 +62,7 @@ impl FastDivmod {
     }
 }
 
+#[cfg(feature = "cuda")]
+use cudarc::driver::DeviceRepr;
+#[cfg(feature = "cuda")]
 unsafe impl DeviceRepr for FastDivmod {}


### PR DESCRIPTION
- Move cudarc::driver::DeviceRepr import behind CUDA feature flag
- Ensure DeviceRepr is only imported when CUDA feature is enabled
- Maintain clean import structure for FastDivmod struct