### PR TITLE
Update shape manipulation documentation examples to use clone() and S…

### DIFF
--- a/docs/user_guide/shape_manipulate/concat.md
+++ b/docs/user_guide/shape_manipulate/concat.md
@@ -20,7 +20,7 @@ A new tensor containing all the input tensors concatenated along the specified a
 
 ## Examples:
 ```rust
-use hpt::{Concat, Tensor, TensorError, TensorInfo};
+use hpt::{Concat, Tensor, TensorError, TensorInfo, ShapeManipulate};
 fn main() -> Result<(), TensorError> {
     // Create two 2D tensors
     let a = Tensor::<f32>::new(&[1.0, 2.0, 3.0, 4.0]).reshape(&[2, 2])?;
@@ -31,7 +31,7 @@ fn main() -> Result<(), TensorError> {
     //  [7, 8]]
 
     // Concatenate along axis 0 (vertically)
-    let c = Tensor::concat(vec![&a, &b], 0, false)?;
+    let c = Tensor::concat(vec![a.clone(), b.clone()], 0, false)?;
     // [[1, 2],
     //  [3, 4],
     //  [5, 6],
@@ -39,19 +39,19 @@ fn main() -> Result<(), TensorError> {
     println!("{}", c);
 
     // Concatenate along axis 1 (horizontally)
-    let d = Tensor::concat(vec![&a, &b], 1, false)?;
+    let d = Tensor::concat(vec![a.clone(), b.clone()], 1, false)?;
     // [[1, 2, 5, 6],
     //  [3, 4, 7, 8]]
     println!("{}", d);
 
     // Concatenate with keepdims=true
-    let e = Tensor::concat(vec![&a, &b], 0, true)?;
+    let e = Tensor::concat(vec![a.clone(), b.clone()], 0, true)?;
     // Shape: [2, 2, 2]
     println!("{}", e.shape());
 
     // Will raise an error if shapes don't match along non-concatenating axes
     let f = Tensor::<f32>::new(&[1.0, 2.0, 3.0]).reshape(&[3, 1])?;
-    assert!(Tensor::concat(vec![&a, &f], 1, false).is_err());
+    assert!(Tensor::concat(vec![a.clone(), f.clone()], 1, false).is_err());
 
     Ok(())
 }

--- a/docs/user_guide/shape_manipulate/dstack.md
+++ b/docs/user_guide/shape_manipulate/dstack.md
@@ -14,7 +14,7 @@ A new tensor with input tensors stacked along the third axis.
 
 ## Examples:
 ```rust
-use hpt::{Concat, Tensor, TensorError};
+use hpt::{Concat, Tensor, TensorError, ShapeManipulate};
 fn main() -> Result<(), TensorError> {
     // With 3D tensors
     let a = Tensor::<f32>::new(&[1.0, 2.0, 3.0, 4.0]).reshape(&[2, 2, 1])?;
@@ -24,7 +24,7 @@ fn main() -> Result<(), TensorError> {
     // [[[5], [6]],
     //  [[7], [8]]]
 
-    let c = Tensor::dstack(vec![&a, &b])?;
+    let c = Tensor::dstack(vec![a.clone(), b.clone()])?;
     // [[[1, 5], [2, 6]],
     //  [[3, 7], [4, 8]]]
     println!("{}", c);
@@ -33,7 +33,7 @@ fn main() -> Result<(), TensorError> {
     let d = Tensor::<f32>::new(&[1.0, 2.0, 3.0, 4.0]).reshape(&[2, 2])?;
     // [[1, 2],
     //  [3, 4]]
-    let e = Tensor::dstack(vec![&d, &d])?;
+    let e = Tensor::dstack(vec![d.clone(), d.clone()])?;
     // [[[1, 1], [2, 2]],
     //  [[3, 3], [4, 4]]]
     println!("{}", e);
@@ -41,13 +41,13 @@ fn main() -> Result<(), TensorError> {
     // With 1D tensors (promoted to [1, n, 1])
     let f = Tensor::<f32>::new(&[1.0, 2.0]);
     let g = Tensor::<f32>::new(&[3.0, 4.0]);
-    let h = Tensor::dstack(vec![&f, &g])?;
+    let h = Tensor::dstack(vec![f.clone(), g.clone()])?;
     // [[[1, 3], [2, 4]]]
     println!("{}", h);
 
     // With scalars (promoted to [1, 1, 1])
     let i = Tensor::<f32>::new(&[1.0]);
-    let j = Tensor::dstack(vec![&i, &i])?;
+    let j = Tensor::dstack(vec![i.clone(), i.clone()])?;
     // [[[1, 1]]]
     println!("{}", j);
 

--- a/docs/user_guide/shape_manipulate/hstack.md
+++ b/docs/user_guide/shape_manipulate/hstack.md
@@ -14,7 +14,7 @@ A new tensor with input tensors stacked horizontally.
 
 ## Examples:
 ```rust
-use hpt::{Concat, Tensor, TensorError};
+use hpt::{Concat, Tensor, TensorError, ShapeManipulate};
 fn main() -> Result<(), TensorError> {
     // With 2D tensors
     let a = Tensor::<f32>::new(&[1.0, 2.0, 3.0, 4.0]).reshape(&[2, 2])?;
@@ -24,7 +24,7 @@ fn main() -> Result<(), TensorError> {
     // [[5, 6],
     //  [7, 8]]
 
-    let c = Tensor::hstack(vec![&a, &b])?;
+    let c = Tensor::hstack(vec![a.clone(), b.clone()])?;
     // [[1, 2, 5, 6],
     //  [3, 4, 7, 8]]
     println!("{}", c);
@@ -32,20 +32,20 @@ fn main() -> Result<(), TensorError> {
     // With 1D tensors
     let d = Tensor::<f32>::new(&[1.0, 2.0]);
     let e = Tensor::<f32>::new(&[3.0, 4.0]);
-    let f = Tensor::hstack(vec![&d, &e])?;
+    let f = Tensor::hstack(vec![d.clone(), e.clone()])?;
     // [1, 2, 3, 4]
     println!("{}", f);
 
     // With scalars (0D tensors)
     let g = Tensor::<f32>::new(&[1.0]);
     let h = Tensor::<f32>::new(&[2.0]);
-    let i = Tensor::hstack(vec![&g, &h])?;
+    let i = Tensor::hstack(vec![g.clone(), h.clone()])?;
     // [1, 2]
     println!("{}", i);
 
     // Will raise an error if heights don't match for 2D tensors
     let j = Tensor::<f32>::new(&[1.0, 2.0, 3.0]).reshape(&[3, 1])?;
-    assert!(Tensor::hstack(vec![&a, &j]).is_err());
+    assert!(Tensor::hstack(vec![a.clone(), j.clone()]).is_err());
 
     Ok(())
 }

--- a/docs/user_guide/shape_manipulate/vstack.md
+++ b/docs/user_guide/shape_manipulate/vstack.md
@@ -14,7 +14,7 @@ A new tensor with input tensors stacked vertically.
 
 ## Examples:
 ```rust
-use hpt::{Concat, Tensor, TensorError};
+use hpt::{Concat, Tensor, TensorError, ShapeManipulate};
 fn main() -> Result<(), TensorError> {
     // Create two 2D tensors
     let a = Tensor::<f32>::new(&[1.0, 2.0, 3.0]).reshape(&[1, 3])?;
@@ -23,7 +23,7 @@ fn main() -> Result<(), TensorError> {
     // [[4, 5, 6]]
 
     // Stack vertically
-    let c = Tensor::vstack(vec![&a, &b])?;
+    let c = Tensor::vstack(vec![a.clone(), b.clone()])?;
     // [[1, 2, 3],
     //  [4, 5, 6]]
     println!("{}", c);
@@ -31,13 +31,13 @@ fn main() -> Result<(), TensorError> {
     // Works with 1D tensors too
     let d = Tensor::<f32>::new(&[1.0, 2.0, 3.0]);
     let e = Tensor::<f32>::new(&[4.0, 5.0, 6.0]);
-    let f = Tensor::vstack(vec![&d, &e])?;
+    let f = Tensor::vstack(vec![d.clone(), e.clone()])?;
     // [1, 2, 3, 4, 5, 6]
     println!("{}", f);
 
     // Will raise an error if widths don't match
     let g = Tensor::<f32>::new(&[1.0, 2.0]).reshape(&[1, 2])?;
-    assert!(Tensor::vstack(vec![&a, &g]).is_err());
+    assert!(Tensor::vstack(vec![a.clone(), g.clone()]).is_err());
 
     Ok(())
 }

--- a/docs/user_guide/utils/resize_cuda_lru_cache.md
+++ b/docs/user_guide/utils/resize_cuda_lru_cache.md
@@ -4,7 +4,7 @@
 resize_cuda_lru_cache(new_size: usize, device_id: usize)
 ```
 
-Adjusts the size of the memory cache used by the CPU allocator. This function allows dynamic control over memory caching behavior.
+Adjusts the size of the memory cache used by the GPU allocator. This function allows dynamic control over memory caching behavior.
 
 ## Parameters:
 - `new_size`: `usize`
@@ -12,8 +12,8 @@ Adjusts the size of the memory cache used by the CPU allocator. This function al
   - Must be a non-negative integer
   - Determines how many memory allocations can be cached
 - `device_id`: `usize`
-  - ID of the CPU device
-  - Usually 0 for single CPU systems
+  - ID of the GPU device
+  - Usually 0 for single GPU
 
 ## Behavior
 - When `new_size` >= current size:


### PR DESCRIPTION
…hapeManipulate trait

- Modify concat, dstack, hstack, and vstack markdown examples
- Replace references with cloned tensors in method calls
- Add ShapeManipulate trait import to documentation examples
- Fix CUDA LRU cache documentation to correctly reference GPU allocator